### PR TITLE
Handle missing report dates in formatter

### DIFF
--- a/frontend/reports.js
+++ b/frontend/reports.js
@@ -2,8 +2,12 @@ const API = (window.__APP_CONFIG__ && window.__APP_CONFIG__.API_BASE_URL) || "";
 
 function formatDate(dateString) {
     console.log('Inscomig dateString:', dateString);
-    let date = new Date(dateString);
-    if (dateString.endsWith('Z')) {
+    if (!dateString) {
+        return 'Invalid data';
+    }
+    const normalizedDateString = String(dateString);
+    let date = new Date(normalizedDateString);
+    if (normalizedDateString.endsWith('Z')) {
         const offsetMs = date.getTimezoneOffset() * 60 * 1000;
         date = new Date(date.getTime() - offsetMs);
     }


### PR DESCRIPTION
## Summary
- guard against missing report dates before attempting string operations
- normalize report date values to strings prior to UTC offset adjustments
- keep existing validation so malformed dates still fall back to the invalid data label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d908d20da0832290d30e25469b1f43